### PR TITLE
Add flight control keyboard and target indicator

### DIFF
--- a/DepanFxJogl/src/main/java/com/pnambic/depanfx/jogl/JoglKeySymbols.java
+++ b/DepanFxJogl/src/main/java/com/pnambic/depanfx/jogl/JoglKeySymbols.java
@@ -25,4 +25,15 @@ public class JoglKeySymbols {
 
   public static final short KS_MINUS = KeyEvent.VK_MINUS;
   public static final short KS_PLUS = KeyEvent.VK_PLUS;
+
+  // Letter key symbols for flight controls
+  public static final short KS_W = KeyEvent.VK_W;
+  public static final short KS_S = KeyEvent.VK_S;
+  public static final short KS_A = KeyEvent.VK_A;
+  public static final short KS_D = KeyEvent.VK_D;
+  public static final short KS_Q = KeyEvent.VK_Q;
+  public static final short KS_E = KeyEvent.VK_E;
+  public static final short KS_R = KeyEvent.VK_R;
+  public static final short KS_F = KeyEvent.VK_F;
+  public static final short KS_X = KeyEvent.VK_X;
 }

--- a/DepanFxJogl/src/main/java/com/pnambic/depanfx/jogl/JoglRenderer.java
+++ b/DepanFxJogl/src/main/java/com/pnambic/depanfx/jogl/JoglRenderer.java
@@ -155,6 +155,8 @@ public class JoglRenderer {
     if (selectionRect != null) {
       selectionRect.drawSelectRectangle(gl);
     }
+
+    drawTarget(gl);
     gl.glFlush();
     glContext.release();
   }
@@ -365,5 +367,57 @@ public class JoglRenderer {
     // Byte values greater than 127 are negative in Java,
     // due to two's complement representation.
     return intValue & 0xFF;
+  }
+
+  /////////////////////////////////////
+  // Target indicator
+
+  private static final double TARGET_SIZE = 5.0d;
+
+  private void drawTarget(GL2 gl) {
+    JoglCamera.CameraData data = camera.getCurrent();
+
+    float[] camV3 = data.captureCamera();
+    float[] lookV3 = data.captureLookAt();
+    float[] dir = JoglTransforms.direction(lookV3, camV3);
+
+    float[] up = new float[] {0f, 1f, 0f};
+    float[] right = normalize(cross(dir, up));
+    float[] perp = normalize(cross(dir, right));
+
+    scale(right, (float) TARGET_SIZE);
+    scale(perp, (float) TARGET_SIZE);
+
+    float cx = (float) data.lookAtX;
+    float cy = (float) data.lookAtY;
+    float cz = (float) data.lookAtZ;
+
+    gl.glLineWidth(2.0f);
+    gl.glColor3d(1.0, 0.0, 0.0);
+    gl.glBegin(GL2.GL_LINES);
+    gl.glVertex3f(cx - right[0], cy - right[1], cz - right[2]);
+    gl.glVertex3f(cx + right[0], cy + right[1], cz + right[2]);
+    gl.glVertex3f(cx - perp[0], cy - perp[1], cz - perp[2]);
+    gl.glVertex3f(cx + perp[0], cy + perp[1], cz + perp[2]);
+    gl.glEnd();
+  }
+
+  private static float[] cross(float[] a, float[] b) {
+    return new float[] {
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0]
+    };
+  }
+
+  private static float[] normalize(float[] v) {
+    float len = (float) Math.sqrt(v[0]*v[0] + v[1]*v[1] + v[2]*v[2]);
+    return new float[] { v[0]/len, v[1]/len, v[2]/len };
+  }
+
+  private static void scale(float[] v, float s) {
+    v[0] *= s;
+    v[1] *= s;
+    v[2] *= s;
   }
 }

--- a/DepanFxNodeViewGui/src/main/java/com/pnambic/depanfx/nodeview/gui/FlightControl.java
+++ b/DepanFxNodeViewGui/src/main/java/com/pnambic/depanfx/nodeview/gui/FlightControl.java
@@ -1,0 +1,127 @@
+package com.pnambic.depanfx.nodeview.gui;
+
+import com.pnambic.depanfx.jogl.JoglModule;
+import com.pnambic.depanfx.jogl.JoglTransforms;
+import com.pnambic.depanfx.jogl.JoglCamera;
+import javafx.animation.AnimationTimer;
+
+/**
+ * Provide basic flight style controls over the camera.
+ */
+public class FlightControl {
+
+  public static final double UNIT_TURN_D = 5.0d; // degrees per key press
+  public static final double THROTTLE_STEP = 1.0d; // units per second
+
+  private final JoglModule jogl;
+  private final CameraControl cameraControl;
+
+  private double throttle = 0.0d;
+
+  private AnimationTimer flightTimer;
+
+  public FlightControl(JoglModule jogl, CameraControl cameraControl) {
+    this.jogl = jogl;
+    this.cameraControl = cameraControl;
+  }
+
+  public CameraControl getCameraControl() {
+    return cameraControl;
+  }
+
+  public void start() {
+    if (flightTimer != null) {
+      return;
+    }
+    flightTimer = new AnimationTimer() {
+      private long last = 0;
+      @Override
+      public void handle(long now) {
+        if (last != 0 && throttle != 0.0d) {
+          double delta = (now - last) / 1_000_000_000.0d;
+          cameraControl.move(throttle * delta);
+        }
+        last = now;
+      }
+    };
+    flightTimer.start();
+  }
+
+  public void stop() {
+    if (flightTimer != null) {
+      flightTimer.stop();
+      flightTimer = null;
+    }
+  }
+
+  /////////////////
+  // Flight actions
+
+  public void pitchDown() { // nose down
+    rotateOnAxis(-UNIT_TURN_D, getRightAxis());
+  }
+
+  public void pitchUp() {
+    rotateOnAxis(UNIT_TURN_D, getRightAxis());
+  }
+
+  public void rollLeft() {
+    rotateOnAxis(-UNIT_TURN_D, getForwardAxis());
+  }
+
+  public void rollRight() {
+    rotateOnAxis(UNIT_TURN_D, getForwardAxis());
+  }
+
+  public void yawLeft() {
+    rotateOnAxis(-UNIT_TURN_D, new float[] {0f, 1f, 0f});
+  }
+
+  public void yawRight() {
+    rotateOnAxis(UNIT_TURN_D, new float[] {0f, 1f, 0f});
+  }
+
+  public void increaseThrottle() {
+    throttle += THROTTLE_STEP;
+  }
+
+  public void decreaseThrottle() {
+    throttle -= THROTTLE_STEP;
+  }
+
+  public void cutThrottle() {
+    throttle = 0.0d;
+  }
+
+  /////////////////////////
+  // Helpers
+
+  private void rotateOnAxis(double angle, float[] axis) {
+    cameraControl.rotate(angle, axis[0], axis[1], axis[2]);
+  }
+
+  private float[] getForwardAxis() {
+    JoglCamera.CameraData data = jogl.getCurrentCamera();
+    return JoglTransforms.directionV3(data);
+  }
+
+  private float[] getRightAxis() {
+    float[] forward = getForwardAxis();
+    float[] up = new float[] {0f, 1f, 0f};
+    return normalize(cross(forward, up));
+  }
+
+  private static float[] cross(float[] a, float[] b) {
+    return new float[] {
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0]
+    };
+  }
+
+  private static float[] normalize(float[] v) {
+    float len = (float) Math.sqrt(v[0]*v[0] + v[1]*v[1] + v[2]*v[2]);
+    return new float[] { v[0]/len, v[1]/len, v[2]/len };
+  }
+}
+

--- a/DepanFxNodeViewGui/src/main/java/com/pnambic/depanfx/nodeview/gui/FlightKeyActions.java
+++ b/DepanFxNodeViewGui/src/main/java/com/pnambic/depanfx/nodeview/gui/FlightKeyActions.java
@@ -1,0 +1,38 @@
+package com.pnambic.depanfx.nodeview.gui;
+
+import static com.pnambic.depanfx.jogl.JoglKeySymbols.*;
+
+import com.pnambic.depanfx.jogl.JoglModule;
+import com.pnambic.depanfx.jogl.JoglKeyListener.SymbolAction;
+
+/**
+ * Install keyboard actions for flight control.
+ */
+public class FlightKeyActions {
+
+  private FlightKeyActions() {
+    // Prevent instantiation.
+  }
+
+  public static void addActions(JoglModule jogl, FlightControl flight) {
+    jogl.addPressAction(new SymbolAction(KS_W, EMPTY_MASK,
+        (s, m) -> flight.pitchDown()));
+    jogl.addPressAction(new SymbolAction(KS_S, EMPTY_MASK,
+        (s, m) -> flight.pitchUp()));
+    jogl.addPressAction(new SymbolAction(KS_A, EMPTY_MASK,
+        (s, m) -> flight.rollLeft()));
+    jogl.addPressAction(new SymbolAction(KS_D, EMPTY_MASK,
+        (s, m) -> flight.rollRight()));
+    jogl.addPressAction(new SymbolAction(KS_Q, EMPTY_MASK,
+        (s, m) -> flight.yawLeft()));
+    jogl.addPressAction(new SymbolAction(KS_E, EMPTY_MASK,
+        (s, m) -> flight.yawRight()));
+    jogl.addPressAction(new SymbolAction(KS_R, EMPTY_MASK,
+        (s, m) -> flight.increaseThrottle()));
+    jogl.addPressAction(new SymbolAction(KS_F, EMPTY_MASK,
+        (s, m) -> flight.decreaseThrottle()));
+    jogl.addPressAction(new SymbolAction(KS_X, EMPTY_MASK,
+        (s, m) -> flight.cutThrottle()));
+  }
+}
+

--- a/DepanFxNodeViewGui/src/main/java/com/pnambic/depanfx/nodeview/jogl/JoglPane.java
+++ b/DepanFxNodeViewGui/src/main/java/com/pnambic/depanfx/nodeview/jogl/JoglPane.java
@@ -6,6 +6,8 @@ import com.pnambic.depanfx.jogl.JoglShape;
 import com.pnambic.depanfx.nodeview.gui.CameraControl;
 import com.pnambic.depanfx.nodeview.gui.DepanFxNodeViewKeyActions;
 import com.pnambic.depanfx.nodeview.gui.DepanFxNodeViewStatusPanel;
+import com.pnambic.depanfx.nodeview.gui.FlightControl;
+import com.pnambic.depanfx.nodeview.gui.FlightKeyActions;
 import com.pnambic.depanfx.nodeview.tooldata.DepanFxNodeViewCameraData;
 import com.pnambic.depanfx.scene.DepanFxDialogRunner;
 
@@ -32,6 +34,8 @@ public class JoglPane extends BorderPane {
 
   private final CameraControl cameraControl;
 
+  private final FlightControl flightControl;
+
   private final DepanFxDialogRunner dialogRunner;
 
   private ScrollBar hScrollBar;
@@ -46,7 +50,9 @@ public class JoglPane extends BorderPane {
     this.jogl = jogl;
     this.dialogRunner = dialogRunner;
     this.cameraControl = new CameraControl(jogl);
+    this.flightControl = new FlightControl(jogl, cameraControl);
     DepanFxNodeViewKeyActions.addActions(jogl, cameraControl);
+    FlightKeyActions.addActions(jogl, flightControl);
   }
 
   public static JoglPane createJoglPane(
@@ -75,6 +81,8 @@ public class JoglPane extends BorderPane {
 
     jogl.demoDisplay();
 
+    flightControl.start();
+
     // JogAmp Bug #1504: Should start jogl rendering here,
     // not in viewport layout children.
     // jogl.start();
@@ -83,6 +91,8 @@ public class JoglPane extends BorderPane {
   public void release() {
     LOG.info("JoglPane release");
     jogl.stop();
+
+    flightControl.stop();
 
     // May not have allocated if never activated.
     if (statusPanel != null) {


### PR DESCRIPTION
## Summary
- extend key symbol constants with flight keys
- implement FlightControl and accompanying key actions
- integrate flight controls in JoglPane
- render a look-at target indicator in JoglRenderer

## Testing
- `./gradlew test` *(fails: ClassFileReaderTest > testHelloWorld())*

------
https://chatgpt.com/codex/tasks/task_e_6879178ab2a88323bd6d212264089bce