### PR TITLE
Share path renderer across node shapes

### DIFF
--- a/DepanFxJogl/src/main/java/com/pnambic/depanfx/jogl/shapes/AwtShape.java
+++ b/DepanFxJogl/src/main/java/com/pnambic/depanfx/jogl/shapes/AwtShape.java
@@ -23,12 +23,13 @@ import com.pnambic.depanfx.jogl.JoglColor;
 
 public class AwtShape extends NodeShape {
 
-  public RenderShape renderShape;
+  private RenderShape renderShape;
 
   public AwtShape(
       RenderShape renderShape,
       boolean isVisible,
-      JoglColor fillColor, JoglColor edgeColor, JoglColor borderColor, JoglColor highlightColor,
+      JoglColor fillColor, JoglColor edgeColor,
+      JoglColor borderColor, JoglColor highlightColor,
       float borderWidth,
       double shapeX, double shapeY, double shapeZ,
       double targetX, double targetY, double targetZ,
@@ -57,6 +58,10 @@ public class AwtShape extends NodeShape {
         showLabel, labelText, pickObject);
   }
 
+  public void setRenderShape(RenderShape renderShape) {
+    this.renderShape = renderShape;
+  }
+
   @Override
   public AwtShape forUpdate() {
     AwtShape result = new AwtShape(
@@ -69,7 +74,6 @@ public class AwtShape extends NodeShape {
     super.fillUpdate(result);
     return result;
   }
-
 
   @Override
   public boolean contains(double posX, double posY) {

--- a/DepanFxJogl/src/main/java/com/pnambic/depanfx/jogl/shapes/AwtShape.java
+++ b/DepanFxJogl/src/main/java/com/pnambic/depanfx/jogl/shapes/AwtShape.java
@@ -21,16 +21,12 @@ package com.pnambic.depanfx.jogl.shapes;
 import com.jogamp.opengl.GL2;
 import com.pnambic.depanfx.jogl.JoglColor;
 
-import java.awt.Shape;
-
 public class AwtShape extends NodeShape {
 
-  public Shape shapeAwt;
-
-  private PathIteratorRender pathRender;
+  public RenderShape renderShape;
 
   public AwtShape(
-      Shape shapeAwt,
+      RenderShape renderShape,
       boolean isVisible,
       JoglColor fillColor, JoglColor edgeColor, JoglColor borderColor, JoglColor highlightColor,
       float borderWidth,
@@ -43,17 +39,17 @@ public class AwtShape extends NodeShape {
         shapeX, shapeY, shapeZ, targetX, targetY, targetZ,
         showLabel, labelText, pickObject);
 
-    this.shapeAwt = shapeAwt;
+    this.renderShape = renderShape;
   }
 
   public AwtShape(
-      Shape shape,
+      RenderShape renderShape,
       boolean isVisible,
       JoglColor fillColor, JoglColor borderColor, JoglColor highlightColor,
       float borderWidth,
       double initialX, double initialY, double initialZ,
       boolean showLabel, String labelText, Object pickObject) {
-    this(shape, isVisible,
+    this(renderShape, isVisible,
         fillColor, borderColor, borderColor, highlightColor,
         borderWidth,
         initialX, initialY, initialZ,
@@ -64,7 +60,7 @@ public class AwtShape extends NodeShape {
   @Override
   public AwtShape forUpdate() {
     AwtShape result = new AwtShape(
-        shapeAwt, isVisible,
+        renderShape, isVisible,
         shapeColor, edgeColor, borderColor, highlightColor,
         borderWidth,
         shapeX, shapeY, shapeZ,
@@ -77,23 +73,17 @@ public class AwtShape extends NodeShape {
 
   @Override
   public boolean contains(double posX, double posY) {
-    return shapeAwt.contains(posX, posY);
+    return renderShape.getAwtShape().contains(posX, posY);
   }
 
   @Override
   protected void renderShape(GL2 gl) {
-    if (pathRender == null) {
-      pathRender = new PathIteratorRender(shapeAwt);
-    }
-    pathRender.drawShape(gl);
+    renderShape.drawShape(gl);
   }
 
   @Override
   protected void renderBorder(GL2 gl) {
     gl.glLineWidth(borderWidth);
-    if (pathRender == null) {
-      pathRender = new PathIteratorRender(shapeAwt);
-    }
-    pathRender.drawBorder(gl);
+    renderShape.drawBorder(gl);
   }
 }

--- a/DepanFxJogl/src/main/java/com/pnambic/depanfx/jogl/shapes/RenderShape.java
+++ b/DepanFxJogl/src/main/java/com/pnambic/depanfx/jogl/shapes/RenderShape.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 The Depan Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.pnambic.depanfx.jogl.shapes;
 
 import com.jogamp.opengl.GL2;
@@ -11,6 +26,7 @@ import java.awt.Shape;
 public class RenderShape {
 
   private final Shape awtShape;
+
   private final PathIteratorRender pathRender;
 
   public RenderShape(Shape awtShape) {

--- a/DepanFxJogl/src/main/java/com/pnambic/depanfx/jogl/shapes/RenderShape.java
+++ b/DepanFxJogl/src/main/java/com/pnambic/depanfx/jogl/shapes/RenderShape.java
@@ -1,0 +1,32 @@
+package com.pnambic.depanfx.jogl.shapes;
+
+import com.jogamp.opengl.GL2;
+
+import java.awt.Shape;
+
+/**
+ * Bundles a {@link Shape} with its cached {@link PathIteratorRender} so that
+ * multiple node shapes can share the same renderable geometry.
+ */
+public class RenderShape {
+
+  private final Shape awtShape;
+  private final PathIteratorRender pathRender;
+
+  public RenderShape(Shape awtShape) {
+    this.awtShape = awtShape;
+    this.pathRender = new PathIteratorRender(awtShape);
+  }
+
+  public Shape getAwtShape() {
+    return awtShape;
+  }
+
+  public void drawShape(GL2 gl) {
+    pathRender.drawShape(gl);
+  }
+
+  public void drawBorder(GL2 gl) {
+    pathRender.drawBorder(gl);
+  }
+}

--- a/DepanFxNodeViewGui/src/main/java/com/pnambic/depanfx/nodeview/jogl/JoglShapes.java
+++ b/DepanFxNodeViewGui/src/main/java/com/pnambic/depanfx/nodeview/jogl/JoglShapes.java
@@ -5,13 +5,13 @@ import com.pnambic.depanfx.jogl.JoglColor;
 import com.pnambic.depanfx.jogl.JoglShape;
 import com.pnambic.depanfx.jogl.shapes.AwtShape;
 import com.pnambic.depanfx.jogl.shapes.NodeShape;
+import com.pnambic.depanfx.jogl.shapes.RenderShape;
 import com.pnambic.depanfx.jogl.overlays.NodeOverlay;
 import com.pnambic.depanfx.jogl.overlays.NestFoldOverlay;
 import com.pnambic.depanfx.nodeview.tooldata.DepanFxJoglShape;
 import com.pnambic.depanfx.nodeview.tooldata.DepanFxNodeDisplayData;
 import com.pnambic.depanfx.nodeview.tooldata.DepanFxNodeLocationData;
 
-import java.awt.Shape;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -74,7 +74,7 @@ public class JoglShapes {
 
       // Only AWT shapes have a shape
       if (nodeShape instanceof AwtShape awtShape) {
-        awtShape.shapeAwt = getShape(display.nodeShape);
+        awtShape.renderShape = getRenderShape(display.nodeShape);
       }
 
       // Do the update
@@ -146,7 +146,7 @@ public class JoglShapes {
     String nodeName = guessName(node);
 
     return Optional.of(new AwtShape(
-        getShape(display.nodeShape), isVisible,
+        getRenderShape(display.nodeShape), isVisible,
         fillColor, borderColor, highlightColor, 1.0f,
         location.xPos, location.yPos, location.zPos,
         true, nodeName, node));
@@ -156,24 +156,29 @@ public class JoglShapes {
     return node.getId().getSimpleName();
   }
 
-  private static Shape getShape(DepanFxJoglShape joglShape) {
-    switch (joglShape) {
-    case CIRCLE:
-      return JoglShapeKinds.CIRCLE.buildAwtShape();
-    case ELLIPSE:
-      return JoglShapeKinds.ELLIPSE.buildAwtShape();
-    case HEXAGON:
-      return JoglShapeKinds.HEXAGON.buildAwtShape();
-    case RECTANGLE:
-      return JoglShapeKinds.RECTANGLE.buildAwtShape();
-    case ROUNDED_RECTANGLE:
-      return JoglShapeKinds.ROUNDED_RECTANGLE.buildAwtShape();
-    case SQUARE:
-      return JoglShapeKinds.SQUARE.buildAwtShape();
-    default:
-    }
-    return JoglShapeKinds.SQUARE.buildAwtShape();
+  private static RenderShape getRenderShape(DepanFxJoglShape joglShape) {
+    return switch (joglShape) {
+      case CIRCLE -> RENDER_CIRCLE;
+      case ELLIPSE -> RENDER_ELLIPSE;
+      case HEXAGON -> RENDER_HEXAGON;
+      case RECTANGLE -> RENDER_RECTANGLE;
+      case ROUNDED_RECTANGLE -> RENDER_ROUNDED_RECTANGLE;
+      case SQUARE -> RENDER_SQUARE;
+    };
   }
+
+  private static final RenderShape RENDER_SQUARE =
+      new RenderShape(JoglShapeKinds.SQUARE.buildAwtShape());
+  private static final RenderShape RENDER_RECTANGLE =
+      new RenderShape(JoglShapeKinds.RECTANGLE.buildAwtShape());
+  private static final RenderShape RENDER_ROUNDED_RECTANGLE =
+      new RenderShape(JoglShapeKinds.ROUNDED_RECTANGLE.buildAwtShape());
+  private static final RenderShape RENDER_CIRCLE =
+      new RenderShape(JoglShapeKinds.CIRCLE.buildAwtShape());
+  private static final RenderShape RENDER_ELLIPSE =
+      new RenderShape(JoglShapeKinds.ELLIPSE.buildAwtShape());
+  private static final RenderShape RENDER_HEXAGON =
+      new RenderShape(JoglShapeKinds.HEXAGON.buildAwtShape());
 
 
   private static List<NodeOverlay> clearFoldOverlays(

--- a/DepanFxNodeViewGui/src/main/java/com/pnambic/depanfx/nodeview/jogl/JoglShapes.java
+++ b/DepanFxNodeViewGui/src/main/java/com/pnambic/depanfx/nodeview/jogl/JoglShapes.java
@@ -24,6 +24,24 @@ import java.util.stream.Stream;
  */
 public class JoglShapes {
 
+  public static final RenderShape RENDER_SQUARE =
+      new RenderShape(JoglShapeKinds.SQUARE.buildAwtShape());
+
+  public static final RenderShape RENDER_RECTANGLE =
+      new RenderShape(JoglShapeKinds.RECTANGLE.buildAwtShape());
+
+  public static final RenderShape RENDER_ROUNDED_RECTANGLE =
+      new RenderShape(JoglShapeKinds.ROUNDED_RECTANGLE.buildAwtShape());
+
+  public static final RenderShape RENDER_CIRCLE =
+      new RenderShape(JoglShapeKinds.CIRCLE.buildAwtShape());
+
+  public static final RenderShape RENDER_ELLIPSE =
+      new RenderShape(JoglShapeKinds.ELLIPSE.buildAwtShape());
+
+  public static final RenderShape RENDER_HEXAGON =
+      new RenderShape(JoglShapeKinds.HEXAGON.buildAwtShape());
+
   public static void installShape(
       JoglPane joglPane, GraphNode node,
       DepanFxNodeLocationData location,
@@ -74,7 +92,7 @@ public class JoglShapes {
 
       // Only AWT shapes have a shape
       if (nodeShape instanceof AwtShape awtShape) {
-        awtShape.renderShape = getRenderShape(display.nodeShape);
+        awtShape.setRenderShape(getRenderShape(display.nodeShape));
       }
 
       // Do the update
@@ -166,20 +184,6 @@ public class JoglShapes {
       case SQUARE -> RENDER_SQUARE;
     };
   }
-
-  private static final RenderShape RENDER_SQUARE =
-      new RenderShape(JoglShapeKinds.SQUARE.buildAwtShape());
-  private static final RenderShape RENDER_RECTANGLE =
-      new RenderShape(JoglShapeKinds.RECTANGLE.buildAwtShape());
-  private static final RenderShape RENDER_ROUNDED_RECTANGLE =
-      new RenderShape(JoglShapeKinds.ROUNDED_RECTANGLE.buildAwtShape());
-  private static final RenderShape RENDER_CIRCLE =
-      new RenderShape(JoglShapeKinds.CIRCLE.buildAwtShape());
-  private static final RenderShape RENDER_ELLIPSE =
-      new RenderShape(JoglShapeKinds.ELLIPSE.buildAwtShape());
-  private static final RenderShape RENDER_HEXAGON =
-      new RenderShape(JoglShapeKinds.HEXAGON.buildAwtShape());
-
 
   private static List<NodeOverlay> clearFoldOverlays(
       List<NodeOverlay> overlays) {


### PR DESCRIPTION
## Summary
- introduce RenderShape to cache PathIteratorRender for reusable geometry
- delegate AwtShape drawing to shared RenderShape instances
- provide cached RenderShape access in JoglShapes

## Testing
- `./gradlew :DepanFxJogl:test :DepanFxNodeViewGui:test`


------
https://chatgpt.com/codex/tasks/task_e_68a627f1b99083239c17fb14104ac47e