### PR TITLE
Use VBOs for stable line rendering

### DIFF
--- a/DepanFxJogl/src/main/java/com/pnambic/depanfx/jogl/shapes/ArrowPoints.java
+++ b/DepanFxJogl/src/main/java/com/pnambic/depanfx/jogl/shapes/ArrowPoints.java
@@ -19,9 +19,9 @@
 package com.pnambic.depanfx.jogl.shapes;
 
 /**
- * Define the vertexes for different line-based arrow heads.
+ * Define the vertices for different line-based arrow heads.
  *
- * Artistic arrowheads are based on a four control-point model:
+ * <p>Artistic arrowheads are based on a four control-point model:</p>
  *
  * {@snippet:
  *     1
@@ -31,16 +31,16 @@ package com.pnambic.depanfx.jogl.shapes;
  *  2  3  4   3 = middlePoint.
  * }
  *
- * This sequence points works well for closed lines and triangle fans, but
- * not for open line segments (i.e. {@code GL_LINE_STRIP}).
+ * <p>This sequence points works well for closed lines and triangle fans, but
+ * not for open line segments (i.e. {@code GL_LINE_STRIP}).</p>
  *
- * Triangular arrowheads are based on a three point control-point model that
+ * <p>Triangular arrowheads are based on a three point control-point model that
  * drops the 3/middlePoint from the artistic shape.  The remaining control
  * point vertices remain in the same location, but are rendered in a different
  * order.  In order to support open line strips, closed line loops,
- * and triangle fans, the vertices are sequenced in the order [ 2, 1, 4 ].
+ * and triangle fans, the vertices are sequenced in the order [ 2, 1, 4 ].</p>
  */
-public class ArrowLinePoints {
+public class ArrowPoints {
 
   public static final double SEMI_CIRCLE = 180.0d;
 
@@ -52,11 +52,11 @@ public class ArrowLinePoints {
 
   public static final double ARROW_TIP_Y = 0.0d;
 
-  public static final LinePoints ARTISTIC_ARROW_POINTS = buildArtisticPoints();
+  public static final VboLinePoints ARTISTIC_ARROW_POINTS = buildArtisticPoints();
 
-  public static final LinePoints TRIANGLE_ARROW_POINTS = buildTrianglePoints();
+  public static final VboLinePoints TRIANGLE_ARROW_POINTS = buildTrianglePoints();
 
-  private  ArrowLinePoints() {
+  private ArrowPoints() {
     // Prevent instantiation.
   }
 
@@ -64,7 +64,7 @@ public class ArrowLinePoints {
    * Use a different order for the points (2, 1, 4), so GL_LINE_STRIP,
    * LINE_LOOP, and GL_TRIANGLE_FAN all work.
    */
-  public static LinePoints buildTrianglePoints() {
+  public static VboLinePoints buildTrianglePoints() {
 
     double secondPointAngle = calcSecondPointAngle();
     double fourthPointAngle = calcFourthPointAngle();
@@ -82,17 +82,16 @@ public class ArrowLinePoints {
     // Push Point 4
     insert = insertPoint(arrowPoints, insert,
         Math.cos(fourthPointAngle), Math.sin(fourthPointAngle));
-    return new LinePoints(3, arrowPoints);
+    return VboLinePoints.fromLinePoints(new LinePoints(3, arrowPoints));
   }
-
 
   /**
    * Provide four vertices (1, 2, 3, 4) that work for LINE_LOOP
    * and GL_TRIANGLE_FAN.
    *
-   * This vertex sequence is not useful with GL_LINE_STRIP
+   * <p>This vertex sequence is not useful with GL_LINE_STRIP</p>
    */
-  public static LinePoints buildArtisticPoints() {
+  public static VboLinePoints buildArtisticPoints() {
 
     double secondPointAngle = calcSecondPointAngle();
     double fourthPointAngle = calcFourthPointAngle();
@@ -113,7 +112,7 @@ public class ArrowLinePoints {
     // Push Point 4
     insertPoint(arrowPoints, insert,
         Math.cos(fourthPointAngle), Math.sin(fourthPointAngle));
-    return new LinePoints(4, arrowPoints);
+    return VboLinePoints.fromLinePoints(new LinePoints(4, arrowPoints));
   }
 
   private static double calcSecondPointAngle() {

--- a/DepanFxJogl/src/main/java/com/pnambic/depanfx/jogl/shapes/ArrowShapes.java
+++ b/DepanFxJogl/src/main/java/com/pnambic/depanfx/jogl/shapes/ArrowShapes.java
@@ -36,12 +36,12 @@ public class ArrowShapes {
 
     private final int mode;
 
-    private final LinePoints arrowPoints;
+    private final VboLinePoints arrowPoints;
 
     private final float[] transformationMatrix;
 
     protected LineArrow(
-        int mode, LinePoints arrowPoints, float[] transformationMatrix) {
+        int mode, VboLinePoints arrowPoints, float[] transformationMatrix) {
       this.mode = mode;
       this.arrowPoints = arrowPoints;
       this.transformationMatrix = transformationMatrix;
@@ -60,7 +60,7 @@ public class ArrowShapes {
   public static class OpenLineArrow extends LineArrow {
 
     private OpenLineArrow(
-        LinePoints arrowPoints, float[] transformationMatrix) {
+        VboLinePoints arrowPoints, float[] transformationMatrix) {
       super(GL2.GL_LINE_STRIP, arrowPoints, transformationMatrix);
     }
   }
@@ -68,7 +68,7 @@ public class ArrowShapes {
   public static class ClosedLineArrow extends LineArrow {
 
     protected ClosedLineArrow(
-        LinePoints arrowPoints, float[] transformationMatrix) {
+        VboLinePoints arrowPoints, float[] transformationMatrix) {
       super(GL2.GL_LINE_LOOP, arrowPoints, transformationMatrix);
     }
   }
@@ -76,7 +76,7 @@ public class ArrowShapes {
   public static class FilledLineArrow extends LineArrow {
 
     protected FilledLineArrow(
-        LinePoints arrowPoints, float[] transformationMatrix) {
+        VboLinePoints arrowPoints, float[] transformationMatrix) {
       super(GL2.GL_TRIANGLE_FAN, arrowPoints, transformationMatrix);
     }
   }
@@ -87,35 +87,35 @@ public class ArrowShapes {
   public static class Artistic extends FilledLineArrow {
 
     protected Artistic(float[] transformationMatrix) {
-      super(ArrowLinePoints.ARTISTIC_ARROW_POINTS, transformationMatrix);
+      super(ArrowPoints.ARTISTIC_ARROW_POINTS, transformationMatrix);
     }
   }
 
   public static class Chevron extends ClosedLineArrow {
 
     protected Chevron(float[] transformationMatrix) {
-      super(ArrowLinePoints.ARTISTIC_ARROW_POINTS, transformationMatrix);
+      super(ArrowPoints.ARTISTIC_ARROW_POINTS, transformationMatrix);
     }
   }
 
   public static class Filled extends FilledLineArrow {
 
     protected Filled(float[] transformationMatrix) {
-      super(ArrowLinePoints.TRIANGLE_ARROW_POINTS, transformationMatrix);
+      super(ArrowPoints.TRIANGLE_ARROW_POINTS, transformationMatrix);
     }
   }
 
   public static class Triangle extends ClosedLineArrow {
 
     protected Triangle(float[] transformationMatrix) {
-      super(ArrowLinePoints.TRIANGLE_ARROW_POINTS, transformationMatrix);
+      super(ArrowPoints.TRIANGLE_ARROW_POINTS, transformationMatrix);
     }
   }
 
   public static class Open extends OpenLineArrow {
 
     protected Open(float[] transformationMatrix) {
-      super(ArrowLinePoints.TRIANGLE_ARROW_POINTS, transformationMatrix);
+      super(ArrowPoints.TRIANGLE_ARROW_POINTS, transformationMatrix);
     }
   }
 

--- a/DepanFxJogl/src/main/java/com/pnambic/depanfx/jogl/shapes/RichLineRender.java
+++ b/DepanFxJogl/src/main/java/com/pnambic/depanfx/jogl/shapes/RichLineRender.java
@@ -52,6 +52,14 @@ public class RichLineRender implements LineRender {
    */
   private LinePoints linePoints = LinePoints.EMPTY;
 
+  private VboLinePoints vboLinePoints;
+
+  private VboLinePoints disposeVbo;
+
+  private int stableCount;
+
+  private static final int STABLE_LIMIT = 5;
+
   private ArrowShape sourceArrow;
 
   private ArrowShape targetArrow;
@@ -66,6 +74,13 @@ public class RichLineRender implements LineRender {
       LinePointsBuilder builder = new LinePointsBuilder();
       linePoints =
           builder.prepare(lineShape, sourceShape, targetShape);
+
+      // Schedule any existing VBO for disposal.
+      if (vboLinePoints != null) {
+        disposeVbo = vboLinePoints;
+        vboLinePoints = null;
+      }
+      stableCount = 0;
 
       // Attach arrowheads if there is a line
       if (linePoints.hasEndpoints()) {
@@ -85,11 +100,23 @@ public class RichLineRender implements LineRender {
       targetPosX = targetShape.shapeX;
       targetPosY = targetShape.shapeY;
       targetPosZ = targetShape.shapeZ;
+    } else {
+      if (stableCount < STABLE_LIMIT) {
+        stableCount++;
+      }
+      if (vboLinePoints == null && linePoints.hasPoints() && stableCount >= STABLE_LIMIT) {
+        vboLinePoints = VboLinePoints.fromLinePoints(linePoints);
+      }
     }
   }
 
   @Override
   public void draw(GL2 gl, LineShape line) {
+
+    if (disposeVbo != null) {
+      disposeVbo.dispose(gl);
+      disposeVbo = null;
+    }
 
     // Skip it all if there are no vertices to draw.
     if (linePoints.hasPoints()) {
@@ -125,7 +152,11 @@ public class RichLineRender implements LineRender {
   }
 
   private void drawLinePoints(GL2 gl) {
-    linePoints.drawPoints(gl, GL2.GL_LINE_STRIP);
+    if (vboLinePoints != null) {
+      vboLinePoints.drawPoints(gl, GL2.GL_LINE_STRIP);
+    } else {
+      linePoints.drawPoints(gl, GL2.GL_LINE_STRIP);
+    }
   }
 
   private void drawHeadArrow(GL2 gl) {

--- a/DepanFxJogl/src/main/java/com/pnambic/depanfx/jogl/shapes/VboLinePoints.java
+++ b/DepanFxJogl/src/main/java/com/pnambic/depanfx/jogl/shapes/VboLinePoints.java
@@ -1,0 +1,89 @@
+package com.pnambic.depanfx.jogl.shapes;
+
+import com.jogamp.common.nio.Buffers;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+
+import java.nio.FloatBuffer;
+
+/**
+ * Provide a sequence of line coordinates rendered via an OpenGL vertex
+ * buffer object (VBO).
+ */
+public class VboLinePoints {
+
+  public static final int STRIDE = 3;
+
+  public final int pointCount;
+
+  public final float[] linePoints;
+
+  private int vboId;
+
+  public static final VboLinePoints EMPTY = new VboLinePoints(0, null) {
+
+    @Override
+    public void drawPoints(GL2 gl, int mode) {
+      // do nothing - avoid glBindBuffer and draw calls.
+    }
+
+    @Override
+    public void dispose(GL2 gl) {
+      // nothing to release
+    }
+  };
+
+  private VboLinePoints(int pointCount, float[] linePoints) {
+    this.pointCount = pointCount;
+    this.linePoints = linePoints;
+  }
+
+  /** Build a {@link VboLinePoints} from an existing {@link LinePoints}. */
+  public static VboLinePoints fromLinePoints(LinePoints src) {
+    return new VboLinePoints(src.pointCount, src.linePoints);
+  }
+
+  public static int getOffset(int index) {
+    return index * STRIDE;
+  }
+
+  public boolean hasEndpoints() {
+    return pointCount >= 2;
+  }
+
+  public boolean hasPoints() {
+    return pointCount > 0;
+  }
+
+  public void drawPoints(GL2 gl, int mode) {
+    ensureVbo(gl);
+    gl.glBindBuffer(GL.GL_ARRAY_BUFFER, vboId);
+    gl.glEnableClientState(GL2.GL_VERTEX_ARRAY);
+    gl.glVertexPointer(3, GL.GL_FLOAT, 0, 0);
+    gl.glDrawArrays(mode, 0, pointCount);
+    gl.glDisableClientState(GL2.GL_VERTEX_ARRAY);
+    gl.glBindBuffer(GL.GL_ARRAY_BUFFER, 0);
+  }
+
+  /** Release any OpenGL buffers created for this instance. */
+  public void dispose(GL2 gl) {
+    if (vboId != 0) {
+      gl.glDeleteBuffers(1, new int[] { vboId }, 0);
+      vboId = 0;
+    }
+  }
+
+  private void ensureVbo(GL2 gl) {
+    if (vboId != 0) {
+      return;
+    }
+    int[] ids = new int[1];
+    gl.glGenBuffers(1, ids, 0);
+    vboId = ids[0];
+    gl.glBindBuffer(GL.GL_ARRAY_BUFFER, vboId);
+    FloatBuffer buf = Buffers.newDirectFloatBuffer(linePoints);
+    gl.glBufferData(
+        GL.GL_ARRAY_BUFFER, linePoints.length * Float.BYTES, buf, GL.GL_STATIC_DRAW);
+    gl.glBindBuffer(GL.GL_ARRAY_BUFFER, 0);
+  }
+}


### PR DESCRIPTION
## Summary
- Add `VboLinePoints` for VBO-backed line point rendering with lifecycle management and a factory to convert from `LinePoints`
- Build arrowhead geometry using `VboLinePoints` and update arrow shapes to draw via VBOs
- Switch `RichLineRender` to VBO rendering after several stable frames and dispose unused buffers

## Testing
- `./gradlew :DepanFxJogl:test`


------
https://chatgpt.com/codex/tasks/task_e_68a65107b1ac832380dbb0f3d2378a31