### PR TITLE
Add modeless background task monitor dialog

### DIFF
--- a/DepanFxScene/src/main/resources/com/pnambic/depanfx/scene/scene.fxml
+++ b/DepanFxScene/src/main/resources/com/pnambic/depanfx/scene/scene.fxml
@@ -97,6 +97,9 @@
                 <Menu text="View" onShowing="#onMenuShowing">
                      <items>
                         <Menu fx:id="viewPanelsItem" text="Panels"/>
+                        <MenuItem id="viewActiveTasksItem"
+                            text="Background Tasks"
+                            onAction="#handleByRegistry"/>
                       </items>
                 </Menu>
                 <Menu text="Help" onShowing="#onMenuShowing">

--- a/DepanFxTasksGui/src/main/java/com/pnambic/depanfx/tasks/gui/TaskMonitorDialogController.java
+++ b/DepanFxTasksGui/src/main/java/com/pnambic/depanfx/tasks/gui/TaskMonitorDialogController.java
@@ -1,0 +1,169 @@
+package com.pnambic.depanfx.tasks.gui;
+
+import com.pnambic.depanfx.scene.DepanFxFxmlDialog;
+
+import net.rgielen.fxweaver.core.FxmlView;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javafx.beans.binding.Bindings;
+import javafx.scene.control.Label;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.control.ProgressBar;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+import javafx.util.Callback;
+
+import com.pnambic.depanfx.tasks.TaskStatus;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Button;
+
+/**
+ * Controller for the background task monitor dialog.
+ */
+@DepanFxFxmlDialog
+@FxmlView("task-monitor-dialog.fxml")
+public class TaskMonitorDialogController {
+
+  private final TaskMonitorService monitorService;
+
+  @FXML
+  private ListView<TaskMonitorItem> activeTasksView;
+
+  @Autowired
+  public TaskMonitorDialogController(TaskMonitorService monitorService) {
+    this.monitorService = monitorService;
+  }
+
+  @FXML
+  public void initialize() {
+    activeTasksView.setItems(monitorService.getActiveTasks());
+    activeTasksView.setCellFactory(createCellFactory());
+
+    Label placeholder = new Label("No active tasks.");
+    placeholder.getStyleClass().add("placeholder-text");
+    activeTasksView.setPlaceholder(placeholder);
+  }
+
+  private Callback<ListView<TaskMonitorItem>, ListCell<TaskMonitorItem>> createCellFactory() {
+    return list -> new TaskMonitorCell(monitorService);
+  }
+
+  private static class TaskMonitorCell extends ListCell<TaskMonitorItem> {
+
+    private final TaskMonitorService monitorService;
+
+    private final Label titleLabel = new Label();
+
+    private final Label statusLabel = new Label();
+
+    private final ProgressBar progressBar = new ProgressBar();
+
+    private final Label messageLabel = new Label();
+
+    private final Button cancelButton = new Button("Cancel");
+
+    private final VBox container = new VBox(6.0);
+
+    private TaskMonitorItem boundItem;
+
+    TaskMonitorCell(TaskMonitorService monitorService) {
+      this.monitorService = monitorService;
+
+      titleLabel.getStyleClass().add("task-monitor-title");
+      statusLabel.getStyleClass().add("task-monitor-status");
+      messageLabel.getStyleClass().add("task-monitor-message");
+
+      progressBar.setPrefWidth(Double.MAX_VALUE);
+
+      Region spacer = new Region();
+      HBox.setHgrow(spacer, Priority.ALWAYS);
+      HBox header = new HBox(8.0, titleLabel, spacer, statusLabel, cancelButton);
+      header.setFillHeight(false);
+
+      container.getChildren().addAll(header, progressBar, messageLabel);
+      container.getStyleClass().add("task-monitor-cell");
+    }
+
+    @Override
+    protected void updateItem(TaskMonitorItem item, boolean empty) {
+      super.updateItem(item, empty);
+
+      if (boundItem != null) {
+        unbind(boundItem);
+      }
+
+      if (empty || item == null) {
+        boundItem = null;
+        setGraphic(null);
+        return;
+      }
+
+      boundItem = item;
+      bind(item);
+      setGraphic(container);
+    }
+
+    private void bind(TaskMonitorItem item) {
+      titleLabel.textProperty().bind(item.titleProperty());
+      statusLabel.textProperty().bind(
+          Bindings.createStringBinding(
+              () -> buildStatusText(item),
+              item.statusProperty(),
+              item.completedStepsProperty(),
+              item.totalStepsProperty(),
+              item.cancelRequestedProperty()));
+      progressBar.progressProperty().bind(item.progressProperty());
+      messageLabel.textProperty().bind(item.messageProperty());
+      messageLabel.visibleProperty().bind(
+          Bindings.createBooleanBinding(
+              () -> !item.messageProperty().get().isBlank(),
+              item.messageProperty()));
+      messageLabel.managedProperty().bind(messageLabel.visibleProperty());
+
+      cancelButton.disableProperty().bind(
+          Bindings.createBooleanBinding(
+              () -> !isCancelable(item),
+              item.statusProperty(),
+              item.cancelRequestedProperty()));
+      cancelButton.setOnAction(event -> monitorService.cancelTask(item));
+    }
+
+    private void unbind(TaskMonitorItem item) {
+      titleLabel.textProperty().unbind();
+      statusLabel.textProperty().unbind();
+      progressBar.progressProperty().unbind();
+      messageLabel.textProperty().unbind();
+      messageLabel.visibleProperty().unbind();
+      messageLabel.managedProperty().unbind();
+      cancelButton.disableProperty().unbind();
+      cancelButton.setOnAction(null);
+    }
+
+    private boolean isCancelable(TaskMonitorItem item) {
+      TaskStatus status = item.statusProperty().get();
+      return !status.isTerminal() && !item.cancelRequestedProperty().get();
+    }
+
+    private String buildStatusText(TaskMonitorItem item) {
+      TaskStatus status = item.statusProperty().get();
+      if (item.cancelRequestedProperty().get() && !status.isTerminal()) {
+        return "Cancelling";
+      }
+
+      int total = item.totalStepsProperty().get();
+      int complete = item.completedStepsProperty().get();
+      if (total > 0) {
+        return String.format("%s (%d/%d)", status, complete, total);
+      }
+      if (complete > 0) {
+        return String.format("%s (%d)", status, complete);
+      }
+      return status.toString();
+    }
+  }
+}

--- a/DepanFxTasksGui/src/main/java/com/pnambic/depanfx/tasks/gui/TaskMonitorDialogService.java
+++ b/DepanFxTasksGui/src/main/java/com/pnambic/depanfx/tasks/gui/TaskMonitorDialogService.java
@@ -1,0 +1,95 @@
+package com.pnambic.depanfx.tasks.gui;
+
+import com.pnambic.depanfx.scene.DepanFxDialogRunner;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javafx.application.Platform;
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
+import javafx.stage.Stage;
+
+/**
+ * Service that presents a modeless dialog listing active background tasks.
+ */
+@Service
+public class TaskMonitorDialogService {
+
+  private final DepanFxDialogRunner dialogRunner;
+
+  private final ObservableList<TaskMonitorItem> activeTasks;
+
+  private Stage dialogStage;
+
+  @Autowired
+  public TaskMonitorDialogService(
+      DepanFxDialogRunner dialogRunner,
+      TaskMonitorService monitorService) {
+    this.dialogRunner = dialogRunner;
+    this.activeTasks = monitorService.getActiveTasks();
+    this.activeTasks.addListener(this::handleActiveTaskChange);
+  }
+
+  /**
+   * Ensure the dialog is visible to the user.
+   */
+  public void showTaskMonitor() {
+    runOnFxThread(() -> {
+      Stage stage = ensureStage();
+      if (stage != null) {
+        if (!stage.isShowing()) {
+          stage.show();
+        }
+        stage.toFront();
+        stage.requestFocus();
+      }
+    });
+  }
+
+  /**
+   * Hide the dialog if it is currently visible.
+   */
+  public void hideTaskMonitor() {
+    runOnFxThread(() -> {
+      if (dialogStage != null) {
+        dialogStage.hide();
+      }
+    });
+  }
+
+  private Stage ensureStage() {
+    if (dialogStage != null) {
+      return dialogStage;
+    }
+
+    DepanFxDialogRunner.Dialog<TaskMonitorDialogController> dialog =
+        dialogRunner.createDialogAndParent(TaskMonitorDialogController.class);
+    Stage stage = dialog.runModeless("Background Tasks");
+    stage.setOnHidden(event -> dialogStage = null);
+    stage.setOnCloseRequest(event -> dialogStage = null);
+    dialogStage = stage;
+    return dialogStage;
+  }
+
+  private void handleActiveTaskChange(
+      ListChangeListener.Change<? extends TaskMonitorItem> change) {
+    runOnFxThread(() -> {
+      if (activeTasks.isEmpty()) {
+        if (dialogStage != null && dialogStage.isShowing()) {
+          dialogStage.hide();
+        }
+      } else if (dialogStage == null || !dialogStage.isShowing()) {
+        showTaskMonitor();
+      }
+    });
+  }
+
+  private void runOnFxThread(Runnable action) {
+    if (Platform.isFxApplicationThread()) {
+      action.run();
+    } else {
+      Platform.runLater(action);
+    }
+  }
+}

--- a/DepanFxTasksGui/src/main/java/com/pnambic/depanfx/tasks/gui/TaskMonitorSceneMenuContribution.java
+++ b/DepanFxTasksGui/src/main/java/com/pnambic/depanfx/tasks/gui/TaskMonitorSceneMenuContribution.java
@@ -1,0 +1,38 @@
+package com.pnambic.depanfx.tasks.gui;
+
+import com.pnambic.depanfx.scene.DepanFxSceneService;
+import com.pnambic.depanfx.scene.DepanFxSceneViewer;
+import com.pnambic.depanfx.scene.plugins.DepanFxSceneMenuContribution;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javafx.event.ActionEvent;
+
+/**
+ * Adds the task monitor dialog to the DepanFX scene menus.
+ */
+@Component
+public class TaskMonitorSceneMenuContribution
+    extends DepanFxSceneMenuContribution.Simple {
+
+  public static final String MENU_ITEM_KEY = "viewActiveTasksItem";
+
+  private final TaskMonitorDialogService dialogService;
+
+  @Autowired
+  public TaskMonitorSceneMenuContribution(TaskMonitorDialogService dialogService) {
+    super(MENU_ITEM_KEY);
+    this.dialogService = dialogService;
+  }
+
+  @Override
+  public boolean forViewer(DepanFxSceneViewer viewer) {
+    return true;
+  }
+
+  @Override
+  public void handleEvent(DepanFxSceneService sceneSrvc, ActionEvent event) {
+    dialogService.showTaskMonitor();
+  }
+}

--- a/DepanFxTasksGui/src/main/resources/com/pnambic/depanfx/tasks/gui/task-monitor-dialog.fxml
+++ b/DepanFxTasksGui/src/main/resources/com/pnambic/depanfx/tasks/gui/task-monitor-dialog.fxml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.layout.BorderPane?>
+
+<BorderPane xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1"
+    fx:controller="com.pnambic.depanfx.tasks.gui.TaskMonitorDialogController"
+    prefWidth="460.0" prefHeight="320.0">
+  <top>
+    <Label text="Background Tasks"
+        BorderPane.alignment="CENTER_LEFT"
+        styleClass="dialog-header" />
+  </top>
+  <center>
+    <ListView fx:id="activeTasksView" focusTraversable="false" />
+  </center>
+  <padding>
+    <Insets top="12.0" right="12.0" bottom="12.0" left="12.0" />
+  </padding>
+</BorderPane>


### PR DESCRIPTION
## Summary
- add a reusable JavaFX dialog that renders active background tasks with progress and cancel controls
- provide a dialog service that manages the modeless stage and reacts to task activity
- register a scene menu contribution so the new dialog can be opened from the View menu

## Testing
- ./gradlew :DepanFxTasksGui:check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914fccc4f6083238e9fbcd6f90540e4)