### PR TITLE
Refine workspace resource load task handling

### DIFF
--- a/DepanFxPerspective/build.gradle
+++ b/DepanFxPerspective/build.gradle
@@ -19,4 +19,5 @@ dependencies {
   implementation project(':DepanFxGraphDoc')
   implementation project(':DepanFxWorkspace')
   implementation project(':DepanFxScene')
+  implementation project(':DepanFxTasks')
 }

--- a/DepanFxPerspective/src/main/java/com/pnambic/depanfx/perspective/plugins/DepanFxResourceRegistry.java
+++ b/DepanFxPerspective/src/main/java/com/pnambic/depanfx/perspective/plugins/DepanFxResourceRegistry.java
@@ -17,10 +17,12 @@ package com.pnambic.depanfx.perspective.plugins;
 
 import com.pnambic.depanfx.scene.DepanFxDialogRunner;
 import com.pnambic.depanfx.scene.DepanFxSceneService;
+import com.pnambic.depanfx.tasks.TaskSubmission;
 import com.pnambic.depanfx.workspace.DepanFxProjectDocument;
 import com.pnambic.depanfx.workspace.DepanFxWorkspace;
 import com.pnambic.depanfx.workspace.DepanFxWorkspaceResource;
 import com.pnambic.depanfx.workspace.projects.DepanFxMemoryProject;
+import com.pnambic.depanfx.workspace.tasks.WorkspaceTaskService;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,8 +31,11 @@ import org.springframework.stereotype.Component;
 
 import java.util.Collection;
 import java.util.Optional;
+import java.util.concurrent.CancellationException;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+
+import javafx.application.Platform;
 
 /**
  * A registry of resources.
@@ -38,15 +43,19 @@ import java.util.stream.Stream;
 @Component
 public class DepanFxResourceRegistry {
 
-  private static Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(DepanFxResourceRegistry.class);
 
   private final Collection<DepanFxResourceRegistryContribution<?>> contribs;
 
+  private final WorkspaceTaskService workspaceTaskService;
+
   @Autowired
   public DepanFxResourceRegistry(
-      Collection<DepanFxResourceRegistryContribution<?>> contribs) {
+      Collection<DepanFxResourceRegistryContribution<?>> contribs,
+      WorkspaceTaskService workspaceTaskService) {
     this.contribs = contribs;
+    this.workspaceTaskService = workspaceTaskService;
   }
 
   /**
@@ -87,7 +96,7 @@ public class DepanFxResourceRegistry {
       DepanFxWorkspace workspace,
       DepanFxProjectDocument document) {
     return selectContributions(contribs.stream(), workspace, document);
-    }
+  }
 
   /**
    * Use the principal contribution to open the supplied document.
@@ -100,20 +109,31 @@ public class DepanFxResourceRegistry {
         .flatMap(c -> c.loadResource(workspace, document));
   }
 
-  public Optional<?> fetchResource(
+  public TaskSubmission<Optional<DepanFxWorkspaceResource<?>>> fetchResource(
       DepanFxWorkspace workspace,
       DepanFxProjectDocument document,
       DepanFxResourceRegistryContribution<?> c,
       Consumer<DepanFxWorkspaceResource<?>> onResourceLoad) {
-    c.loadResource(workspace, document)
-        .ifPresentOrElse(
-            onResourceLoad::accept,
-            () -> LOG.warn("Unable to load document: {}", document));
+    TaskSubmission<Optional<DepanFxWorkspaceResource<?>>> submission =
+        workspaceTaskService.submitResourceLoad(workspace, document, c);
 
-    return Optional.empty();
+    submission.resultFuture().whenComplete((resource, error) -> {
+      if (error != null) {
+        if (error instanceof CancellationException) {
+          return;
+        }
+        LOG.warn("Unable to load document: {}", document, error);
+        return;
+      }
+      resource.ifPresentOrElse(
+          r -> runOnFxThread(() -> onResourceLoad.accept(r)),
+          () -> LOG.warn("Unable to load document: {}", document));
+    });
+
+    return submission;
   }
 
-  public void openDocument(
+  public Optional<TaskSubmission<Optional<DepanFxWorkspaceResource<?>>>> openDocument(
       DepanFxWorkspace workspace,
       DepanFxSceneService sceneSrvc,
       DepanFxProjectDocument document) {
@@ -123,17 +143,19 @@ public class DepanFxResourceRegistry {
 
     if (optContrib.isEmpty()) {
       LOG.warn("No contribution to open document: {}", document);
-      return;
+      return Optional.empty();
     }
 
     DepanFxResourceRegistryContribution<?> contrib = optContrib.get();
-    fetchResource(
-        workspace, document, contrib,
-        r -> DepanFxResourceRegistryContribution.dispatchResource(
-            workspace, sceneSrvc, contrib, r));
+    TaskSubmission<Optional<DepanFxWorkspaceResource<?>>> submission =
+        fetchResource(
+            workspace, document, contrib,
+            r -> DepanFxResourceRegistryContribution.dispatchResource(
+                workspace, sceneSrvc, contrib, r));
+    return Optional.of(submission);
   }
 
-  public void openDialog(
+  public Optional<TaskSubmission<Optional<DepanFxWorkspaceResource<?>>>> openDialog(
       DepanFxWorkspace workspace,
       DepanFxDialogRunner dialogRunner,
       DepanFxProjectDocument document) {
@@ -143,7 +165,7 @@ public class DepanFxResourceRegistry {
 
     if (optContrib.isEmpty()) {
       LOG.warn("No contribution to open document: {}", document);
-      return;
+      return Optional.empty();
     }
 
     DepanFxResourceRegistryContribution<?> contrib = optContrib.get();
@@ -151,13 +173,23 @@ public class DepanFxResourceRegistry {
       LOG.warn("Principal contribution {} requires a panel."
           + "  Unable to render document {} with dialog.",
           contrib.getResourceLabel(), document);
-      return;
+      return Optional.empty();
     }
 
-    fetchResource(
-        workspace, document, contrib,
-        r -> DepanFxResourceRegistryContribution.dispatchDialog(
-            workspace, dialogRunner, contrib, r));
+    TaskSubmission<Optional<DepanFxWorkspaceResource<?>>> submission =
+        fetchResource(
+            workspace, document, contrib,
+            r -> DepanFxResourceRegistryContribution.dispatchDialog(
+                workspace, dialogRunner, contrib, r));
+    return Optional.of(submission);
+  }
+
+  private void runOnFxThread(Runnable action) {
+    if (Platform.isFxApplicationThread()) {
+      action.run();
+    } else {
+      Platform.runLater(action);
+    }
   }
 
   private Optional<DepanFxResourceRegistryContribution<?>>

--- a/DepanFxPerspective/src/main/java/com/pnambic/depanfx/workspace/tasks/ResourceLoadTask.java
+++ b/DepanFxPerspective/src/main/java/com/pnambic/depanfx/workspace/tasks/ResourceLoadTask.java
@@ -1,0 +1,170 @@
+package com.pnambic.depanfx.workspace.tasks;
+
+import com.pnambic.depanfx.perspective.plugins.DepanFxResourceRegistryContribution;
+import com.pnambic.depanfx.tasks.DeferredTask;
+import com.pnambic.depanfx.tasks.ProgressMonitor;
+import com.pnambic.depanfx.tasks.TaskStatus;
+import com.pnambic.depanfx.workspace.DepanFxProjectDocument;
+import com.pnambic.depanfx.workspace.DepanFxWorkspace;
+import com.pnambic.depanfx.workspace.DepanFxWorkspaceResource;
+
+import java.text.MessageFormat;
+import java.util.Optional;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class ResourceLoadTask
+    implements DeferredTask<Optional<DepanFxWorkspaceResource<?>>> {
+
+  private final DepanFxResourceRegistryContribution<?> contribution;
+
+  private final DepanFxWorkspace workspace;
+
+  private final DepanFxProjectDocument document;
+
+  private final AtomicReference<TaskStatus> status =
+      new AtomicReference<>(TaskStatus.READY);
+
+  private final AtomicReference<Optional<DepanFxWorkspaceResource<?>>> result =
+      new AtomicReference<>(Optional.empty());
+
+  private final AtomicReference<Exception> failure = new AtomicReference<>();
+
+  private volatile String message = "";
+
+  public ResourceLoadTask(
+      DepanFxResourceRegistryContribution<?> contribution,
+      DepanFxWorkspace workspace,
+      DepanFxProjectDocument document) {
+    this.contribution = contribution;
+    this.workspace = workspace;
+    this.document = document;
+  }
+
+  @Override
+  public String getTaskTitle() {
+    return MessageFormat.format(
+        "Load {0}", document.getMemberPath().getFileName());
+  }
+
+  @Override
+  public int getTotalSteps() {
+    return 1;
+  }
+
+  @Override
+  public void start(ProgressMonitor monitor) throws Exception {
+    if (!status.compareAndSet(TaskStatus.READY, TaskStatus.RUNNING)) {
+      if (status.get() == TaskStatus.CANCELLED) {
+        throw cancelled();
+      }
+    }
+
+    String beginMessage = MessageFormat.format(
+        "Loading {0}", document.getMemberPath());
+    message = beginMessage;
+    monitor.updateMessage(beginMessage);
+
+    try {
+      checkCancelled(monitor);
+
+      Optional<DepanFxWorkspaceResource<?>> loaded =
+          contribution.loadResource(workspace, document)
+              .map(resource -> (DepanFxWorkspaceResource<?>) resource);
+
+      checkCancelled(monitor);
+
+      result.set(loaded);
+      if (loaded.isPresent()) {
+        String successMessage = MessageFormat.format(
+            "Loaded {0}", document.getMemberPath());
+        message = successMessage;
+        monitor.advance(1, successMessage);
+        monitor.complete();
+        status.set(TaskStatus.COMPLETED);
+      } else {
+        String missingMessage = MessageFormat.format(
+            "No resource produced for {0}", document.getMemberPath());
+        message = missingMessage;
+        monitor.advance(1, missingMessage);
+        monitor.complete();
+        status.set(TaskStatus.COMPLETED);
+      }
+    } catch (CancellationException cancel) {
+      message = cancellationMessage();
+      status.set(TaskStatus.CANCELLED);
+      monitor.updateMessage(message);
+      throw cancel;
+    } catch (Exception error) {
+      status.set(TaskStatus.FAILED);
+      failure.set(error);
+      String errorMessage = MessageFormat.format(
+          "Failed to load {0}: {1}",
+          document.getMemberPath(),
+          error.getMessage());
+      message = errorMessage;
+      monitor.updateMessage(errorMessage);
+      throw error;
+    }
+  }
+
+  @Override
+  public TaskStatus getStatus() {
+    return status.get();
+  }
+
+  @Override
+  public Optional<DepanFxWorkspaceResource<?>> getResult() throws Exception {
+    Exception error = failure.get();
+    if (error != null) {
+      throw error;
+    }
+    if (status.get() == TaskStatus.CANCELLED) {
+      throw cancelled();
+    }
+    return result.get();
+  }
+
+  @Override
+  public void cancel() {
+    TaskStatus current;
+    do {
+      current = status.get();
+      if (current.isTerminal()) {
+        return;
+      }
+    } while (!status.compareAndSet(current, TaskStatus.CANCELLED));
+    message = cancellationMessage();
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public DepanFxResourceRegistryContribution<?> getContribution() {
+    return contribution;
+  }
+
+  public DepanFxWorkspace getWorkspace() {
+    return workspace;
+  }
+
+  public DepanFxProjectDocument getDocument() {
+    return document;
+  }
+
+  private void checkCancelled(ProgressMonitor monitor) {
+    if (status.get() == TaskStatus.CANCELLED || monitor.isCancelled()) {
+      throw cancelled();
+    }
+  }
+
+  private CancellationException cancelled() {
+    return new CancellationException(cancellationMessage());
+  }
+
+  private String cancellationMessage() {
+    return MessageFormat.format(
+        "Cancelled load for {0}", document.getMemberPath());
+  }
+}

--- a/DepanFxPerspective/src/main/java/com/pnambic/depanfx/workspace/tasks/WorkspaceTaskService.java
+++ b/DepanFxPerspective/src/main/java/com/pnambic/depanfx/workspace/tasks/WorkspaceTaskService.java
@@ -1,0 +1,32 @@
+package com.pnambic.depanfx.workspace.tasks;
+
+import com.pnambic.depanfx.perspective.plugins.DepanFxResourceRegistryContribution;
+import com.pnambic.depanfx.tasks.TaskExecutorService;
+import com.pnambic.depanfx.tasks.TaskSubmission;
+import com.pnambic.depanfx.workspace.DepanFxProjectDocument;
+import com.pnambic.depanfx.workspace.DepanFxWorkspace;
+import com.pnambic.depanfx.workspace.DepanFxWorkspaceResource;
+
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class WorkspaceTaskService {
+
+  private final TaskExecutorService taskExecutorService;
+
+  public WorkspaceTaskService(TaskExecutorService taskExecutorService) {
+    this.taskExecutorService = taskExecutorService;
+  }
+
+  public TaskSubmission<Optional<DepanFxWorkspaceResource<?>>> submitResourceLoad(
+      DepanFxWorkspace workspace,
+      DepanFxProjectDocument document,
+      DepanFxResourceRegistryContribution<?> contribution) {
+
+    ResourceLoadTask loadTask =
+        new ResourceLoadTask(contribution, workspace, document);
+    return taskExecutorService.submitTask(loadTask);
+  }
+}

--- a/DepanFxPerspective/src/main/java/module-info.java
+++ b/DepanFxPerspective/src/main/java/module-info.java
@@ -8,6 +8,7 @@ module depanfx.perspective {
     requires org.slf4j;
     requires spring.context;
     requires spring.beans;
+    requires depanfx.tasks;
     requires depanfx.graph_doc;
     requires depanfx.workspace;
     requires depanfx.scene;
@@ -21,10 +22,13 @@ module depanfx.perspective {
         to javafx.fxml, depanfx.scene;
     opens com.pnambic.depanfx.perspective.plugins
         to javafx.fxml, net.rgielen.fxweaver.core, spring.beans;
+    opens com.pnambic.depanfx.workspace.tasks
+        to spring.beans, spring.context;
 
     exports com.pnambic.depanfx.perspective;
     exports com.pnambic.depanfx.perspective.chooser;
     exports com.pnambic.depanfx.perspective.graphdoc;
     exports com.pnambic.depanfx.perspective.plugins;
     exports com.pnambic.depanfx.perspective.workspace.controls;
+    exports com.pnambic.depanfx.workspace.tasks;
 }


### PR DESCRIPTION
## Summary
- tighten `ResourceLoadTask` status, cancellation, and message tracking so asynchronous loads honour cancellation requests and report progress consistently
- update the resource registry logger declaration and fix the contributions stream formatting

## Testing
- ./gradlew --console=plain :DepanFxWorkspace:check :DepanFxPerspective:check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918cc73f6e88323a2164db9e0003133)