### PR TITLE
Add node list viewer data editor dialog

### DIFF
--- a/DepanFxNodeListViewer/src/main/java/com/pnambic/depanfx/nodelist/viewer/DepanFxNodeListViewerConfiguration.java
+++ b/DepanFxNodeListViewer/src/main/java/com/pnambic/depanfx/nodelist/viewer/DepanFxNodeListViewerConfiguration.java
@@ -26,9 +26,11 @@ import com.pnambic.depanfx.nodelist.gui.DepanFxSaveNodeListDialog;
 import com.pnambic.depanfx.nodelist.gui.columns.DepanFxColumnRegistry;
 import com.pnambic.depanfx.nodelist.model.DepanFxNodeList;
 import com.pnambic.depanfx.nodelist.tooldata.DepanFxNodeListTableViewData;
+import com.pnambic.depanfx.nodelist.viewdata.DepanFxNodeListViewerData;
 import com.pnambic.depanfx.perspective.plugins.DepanFxResourceRegistryContribution;
 import com.pnambic.depanfx.scene.DepanFxDialogRunner;
 import com.pnambic.depanfx.scene.DepanFxSceneService;
+import com.pnambic.depanfx.scene.plugins.DepanFxNewAnalysisContribution;
 import com.pnambic.depanfx.scene.plugins.DepanFxSceneMenuContribution;
 import com.pnambic.depanfx.scene.plugins.DepanFxSceneMenuItems;
 import com.pnambic.depanfx.workspace.DepanFxWorkspace;
@@ -43,6 +45,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.nio.file.Path;
+
+import javafx.scene.control.MenuItem;
 
 @Configuration
 public class DepanFxNodeListViewerConfiguration {
@@ -92,6 +96,23 @@ public class DepanFxNodeListViewerConfiguration {
       DepanFxNodeFiltersRegistry filterRegistry,
       DepanFxNodeFiltersDialogRegistry filterDialogRegistry) {
     return new GraphDocResourceContribution(
+        columnRegistry, infoRegistry, matcherRegistry,
+        filterRegistry, filterDialogRegistry);
+  }
+
+  @Bean
+  public DepanFxNewAnalysisContribution nodeListViewerEditor(
+      DepanFxWorkspace workspace,
+      DepanFxSceneService sceneSrvc,
+      DepanFxDialogRunner dialogRunner,
+      DepanFxColumnRegistry columnRegistry,
+      DepanFxInfoRegistry infoRegistry,
+      DepanFxLinkMatchersRegistry matcherRegistry,
+      DepanFxNodeFiltersRegistry filterRegistry,
+      DepanFxNodeFiltersDialogRegistry filterDialogRegistry) {
+
+    return new NodeListViewerEditorContribution(
+        workspace, sceneSrvc, dialogRunner,
         columnRegistry, infoRegistry, matcherRegistry,
         filterRegistry, filterDialogRegistry);
   }
@@ -279,6 +300,69 @@ public class DepanFxNodeListViewerConfiguration {
           graphRsrc,
           DepanFxNodeListViewBuiltIns.guessTableViewResource(
               workspace, graphRsrc));
+    }
+  }
+
+  private static class NodeListViewerEditorContribution
+      implements DepanFxNewAnalysisContribution {
+
+    private final DepanFxWorkspace workspace;
+
+    private final DepanFxSceneService sceneSrvc;
+
+    private final DepanFxDialogRunner dialogRunner;
+
+    private final DepanFxColumnRegistry columnRegistry;
+
+    private final DepanFxInfoRegistry infoRegistry;
+
+    private final DepanFxLinkMatchersRegistry matcherRegistry;
+
+    private final DepanFxNodeFiltersRegistry filterRegistry;
+
+    private final DepanFxNodeFiltersDialogRegistry filterDialogRegistry;
+
+    public NodeListViewerEditorContribution(
+        DepanFxWorkspace workspace,
+        DepanFxSceneService sceneSrvc,
+        DepanFxDialogRunner dialogRunner,
+        DepanFxColumnRegistry columnRegistry,
+        DepanFxInfoRegistry infoRegistry,
+        DepanFxLinkMatchersRegistry matcherRegistry,
+        DepanFxNodeFiltersRegistry filterRegistry,
+        DepanFxNodeFiltersDialogRegistry filterDialogRegistry) {
+
+      this.workspace = workspace;
+      this.sceneSrvc = sceneSrvc;
+      this.dialogRunner = dialogRunner;
+      this.columnRegistry = columnRegistry;
+      this.infoRegistry = infoRegistry;
+      this.matcherRegistry = matcherRegistry;
+      this.filterRegistry = filterRegistry;
+      this.filterDialogRegistry = filterDialogRegistry;
+    }
+
+    @Override
+    public MenuItem createNewResourceMenuItem() {
+      MenuItem result = new MenuItem(OPEN_LIST_VIEW_LABEL);
+      result.setOnAction(e -> runEditorDialog());
+      return result;
+    }
+
+    private void runEditorDialog() {
+      DepanFxNodeListViewerDataDialog.runEditDialog(workspace, dialogRunner)
+          .ifPresent(this::addViewerFromData);
+    }
+
+    private void addViewerFromData(DepanFxNodeListViewerData viewerData) {
+      DepanFxNodeListViewer viewer = new DepanFxNodeListViewer(
+          viewerData.getViewerTitle(), workspace, dialogRunner,
+          columnRegistry, infoRegistry, matcherRegistry,
+          filterRegistry, filterDialogRegistry);
+
+      sceneSrvc.addViewer(viewer);
+      viewer.initFromNodeListResource(
+          viewerData.getNodeListRsrc(), viewerData.getTableViewRsrc());
     }
   }
 

--- a/DepanFxNodeListViewer/src/main/java/com/pnambic/depanfx/nodelist/viewer/DepanFxNodeListViewerDataDialog.java
+++ b/DepanFxNodeListViewer/src/main/java/com/pnambic/depanfx/nodelist/viewer/DepanFxNodeListViewerDataDialog.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2025 The Depan Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pnambic.depanfx.nodelist.viewer;
+
+import com.pnambic.depanfx.nodelist.gui.DepanFxNodeListChooser;
+import com.pnambic.depanfx.nodelist.gui.DepanFxSaveNodeListDialog;
+import com.pnambic.depanfx.nodelist.gui.DepanFxNodeListTableViewSaveDialog;
+import com.pnambic.depanfx.nodelist.model.DepanFxNodeList;
+import com.pnambic.depanfx.nodelist.tooldata.DepanFxNodeListTableViewData;
+import com.pnambic.depanfx.nodelist.viewdata.DepanFxNodeListViewerData;
+import com.pnambic.depanfx.scene.DepanFxDialogRunner;
+import com.pnambic.depanfx.scene.DepanFxDialogRunner.Dialog;
+import com.pnambic.depanfx.scene.DepanFxFxmlDialog;
+import com.pnambic.depanfx.workspace.DepanFxWorkspace;
+import com.pnambic.depanfx.workspace.DepanFxWorkspaceFactory;
+import com.pnambic.depanfx.workspace.DepanFxWorkspaceResource;
+import com.pnambic.depanfx.workspace.projects.DepanFxProjects;
+
+import net.rgielen.fxweaver.core.FxmlView;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+
+import javafx.fxml.FXML;
+import javafx.scene.Scene;
+import javafx.scene.control.TextField;
+
+@DepanFxFxmlDialog
+@FxmlView("node-list-viewer-data-dialog.fxml")
+public class DepanFxNodeListViewerDataDialog {
+
+  private final DepanFxWorkspace workspace;
+
+  private final DepanFxDialogRunner dialogRunner;
+
+  @FXML
+  private TextField viewerTitleField;
+
+  @FXML
+  private TextField nodeListField;
+
+  @FXML
+  private TextField tableViewField;
+
+  private DepanFxNodeListChooser.NodeListControl nodeListControl;
+
+  private DepanFxWorkspaceResource<DepanFxNodeListTableViewData> tableViewRsrc;
+
+  private Optional<DepanFxNodeListViewerData> viewerData = Optional.empty();
+
+  @Autowired
+  public DepanFxNodeListViewerDataDialog(
+      DepanFxWorkspace workspace,
+      DepanFxDialogRunner dialogRunner) {
+    this.workspace = workspace;
+    this.dialogRunner = dialogRunner;
+  }
+
+  public static Optional<DepanFxNodeListViewerData> runEditDialog(
+      DepanFxWorkspace workspace,
+      DepanFxDialogRunner dialogRunner) {
+
+    Dialog<DepanFxNodeListViewerDataDialog> editDlg =
+        dialogRunner.createDialogAndParent(DepanFxNodeListViewerDataDialog.class);
+    editDlg.runDialog("Node List Viewer");
+    return editDlg.getController().getViewerData();
+  }
+
+  public static Optional<DepanFxNodeListViewerData> runEditDialog(
+      DepanFxWorkspace workspace,
+      DepanFxDialogRunner dialogRunner,
+      DepanFxNodeListViewerData initialData) {
+
+    Dialog<DepanFxNodeListViewerDataDialog> editDlg =
+        dialogRunner.createDialogAndParent(DepanFxNodeListViewerDataDialog.class);
+    editDlg.getController().setViewerData(initialData);
+    editDlg.runDialog("Node List Viewer");
+    return editDlg.getController().getViewerData();
+  }
+
+  public Scene getScene() {
+    return viewerTitleField.getScene();
+  }
+
+  @FXML
+  public void initialize() {
+    nodeListControl = new DepanFxNodeListChooser.NodeListControl(
+        workspace, dialogRunner, nodeListField);
+  }
+
+  public Optional<DepanFxNodeListViewerData> getViewerData() {
+    return viewerData;
+  }
+
+  public void setViewerData(DepanFxNodeListViewerData viewerData) {
+    viewerTitleField.setText(viewerData.getViewerTitle());
+    setNodeListResource(viewerData.getNodeListRsrc());
+    setTableViewResource(viewerData.getTableViewRsrc());
+    this.viewerData = Optional.of(viewerData);
+  }
+
+  @FXML
+  public void onSelectNodeList() {
+    DepanFxNodeListChooser.runNodeListChooser(workspace, dialogRunner, getScene())
+        .ifPresent(this::setNodeListResource);
+  }
+
+  @FXML
+  public void onSaveNodeList() {
+    Optional.ofNullable(nodeListControl.getNodeListResource())
+        .flatMap(r -> DepanFxSaveNodeListDialog.runSaveNodeList(dialogRunner, r))
+        .ifPresent(this::setNodeListResource);
+  }
+
+  @FXML
+  public void onSelectTableView() {
+    DepanFxNodeListTableViewSaveDialog.runTableViewChooser(
+        workspace, dialogRunner, getScene())
+        .ifPresent(this::setTableViewResource);
+  }
+
+  @FXML
+  public void onCancel() {
+    viewerData = Optional.empty();
+    close();
+  }
+
+  @FXML
+  public void onConfirm() {
+    if (hasSelections()) {
+      viewerData = Optional.of(new DepanFxNodeListViewerData(
+          viewerTitleField.getText(),
+          nodeListControl.getNodeListResource(),
+          tableViewRsrc));
+    } else {
+      viewerData = Optional.empty();
+    }
+    close();
+  }
+
+  private void close() {
+    viewerTitleField.getScene().getWindow().hide();
+  }
+
+  private boolean hasSelections() {
+    return nodeListControl.getNodeListResource() != null && tableViewRsrc != null;
+  }
+
+  private void setNodeListResource(
+      DepanFxWorkspaceResource<DepanFxNodeList> nodeListRsrc) {
+    nodeListControl.setNodeListResource(nodeListRsrc);
+    if (viewerTitleField.getText().isBlank()) {
+      viewerTitleField.setText(
+          DepanFxWorkspaceFactory.buildDocTitle(nodeListRsrc.getDocument()));
+    }
+  }
+
+  private void setTableViewResource(
+      DepanFxWorkspaceResource<DepanFxNodeListTableViewData> tableViewRsrc) {
+    this.tableViewRsrc = tableViewRsrc;
+    tableViewField.setText(
+        DepanFxProjects.asSaveLabel(workspace, tableViewRsrc));
+  }
+}

--- a/DepanFxNodeListViewer/src/main/resources/com/pnambic/depanfx/nodelist/viewer/node-list-viewer-data-dialog.fxml
+++ b/DepanFxNodeListViewer/src/main/resources/com/pnambic/depanfx/nodelist/viewer/node-list-viewer-data-dialog.fxml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.RowConstraints?>
+
+<GridPane xmlns="http://javafx.com/javafx/21.0.1"
+    xmlns:fx="http://javafx.com/fxml/1"
+    fx:controller="com.pnambic.depanfx.nodelist.viewer.DepanFxNodeListViewerDataDialog"
+    hgap="6.0" vgap="10.0">
+  <columnConstraints>
+    <ColumnConstraints hgrow="NEVER" minWidth="120.0" />
+    <ColumnConstraints hgrow="ALWAYS" />
+  </columnConstraints>
+  <rowConstraints>
+    <RowConstraints minHeight="30.0"/>
+    <RowConstraints minHeight="30.0"/>
+    <RowConstraints minHeight="30.0"/>
+    <RowConstraints minHeight="40.0"/>
+  </rowConstraints>
+  <padding>
+    <Insets top="12.0" right="12.0" bottom="12.0" left="12.0" />
+  </padding>
+
+  <Label text="Viewer Title" GridPane.rowIndex="0" />
+  <TextField fx:id="viewerTitleField" GridPane.rowIndex="0" GridPane.columnIndex="1" />
+
+  <Label text="Node List" GridPane.rowIndex="1" />
+  <HBox spacing="6.0" GridPane.rowIndex="1" GridPane.columnIndex="1">
+    <TextField fx:id="nodeListField" HBox.hgrow="ALWAYS" />
+    <Button text="Select" onAction="#onSelectNodeList" />
+    <Button text="Save As" onAction="#onSaveNodeList" />
+  </HBox>
+
+  <Label text="Table View" GridPane.rowIndex="2" />
+  <HBox spacing="6.0" GridPane.rowIndex="2" GridPane.columnIndex="1">
+    <TextField fx:id="tableViewField" HBox.hgrow="ALWAYS" />
+    <Button text="Select" onAction="#onSelectTableView" />
+  </HBox>
+
+  <HBox spacing="10.0" GridPane.rowIndex="3" GridPane.columnIndex="1" alignment="CENTER_RIGHT">
+    <Button text="Cancel" onAction="#onCancel" />
+    <Button text="OK" onAction="#onConfirm" />
+  </HBox>
+</GridPane>


### PR DESCRIPTION
## Summary
- add an FXML-backed dialog to pick node list and table view resources for node list viewer data
- register a menu contribution that launches the dialog and opens a viewer from the chosen resources

## Testing
- ./gradlew --console=plain :DepanFxNodeListViewer:compileJava

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692df7b08d888323ac406a5ff5241d5f)